### PR TITLE
#44 Fix - incompatible declaration Product::getTypeInstance()

### DIFF
--- a/packages/Webkul/GraphQLAPI/Models/Catalog/Product.php
+++ b/packages/Webkul/GraphQLAPI/Models/Catalog/Product.php
@@ -16,8 +16,9 @@ class Product extends BaseModel
      * Retrieve type instance
      *
      * @return AbstractType
+	 * @throws \Exception
      */
-    public function getTypeInstance()
+    public function getTypeInstance(): AbstractType
     {
         if ($this->typeInstance) {
             return $this->typeInstance;


### PR DESCRIPTION
Fixes issue #44 

by updating 
```php
\Webkul\GraphQLAPI\Models\Catalog\Product::getTypeInstance
``` 
declaration, and making it compliant with Bagisto `1.3.3`.

Basically the new version has return types, which are required now in packages extending the base model(s). 

This update doesn't update all return types, of every method, but only the one required to run composer scripts without errors.