### PR TITLE
Revert "uodate code in  GraphQLAPIServiceProvider "

### DIFF
--- a/src/Providers/GraphQLAPIServiceProvider.php
+++ b/src/Providers/GraphQLAPIServiceProvider.php
@@ -34,8 +34,6 @@ class GraphQLAPIServiceProvider extends ServiceProvider
                 request()->merge(['token' => $headerValue[1]]);
             }
         }
-
-        $this->publishes([__DIR__.'/../graphql/schema.graphql' => base_path('graphql/schema.graphql')]);
     }
 
     /**


### PR DESCRIPTION
Reverts bagisto/headless-ecommerce#60

Not needed now using the default lighthouse command.