### PR TITLE
Fixed #248 - Getting Errors in Composer while installing headless-ecommerce in a new project.

### DIFF
--- a/src/Models/CatalogRule/CatalogRule.php
+++ b/src/Models/CatalogRule/CatalogRule.php
@@ -2,6 +2,7 @@
 
 namespace Webkul\GraphQLAPI\Models\CatalogRule;
 
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Webkul\CatalogRule\Models\CatalogRule as BaseModel;
 use Webkul\CatalogRule\Models\CatalogRuleProductProxy;
 use Webkul\CatalogRule\Models\CatalogRuleProductPriceProxy;
@@ -11,7 +12,7 @@ class CatalogRule extends BaseModel
     /**
      * Get the Catalog rule Product that owns the catalog rule.
      */
-    public function catalog_rule_products()
+    public function catalog_rule_products(): HasMany
     {
         return $this->hasMany(CatalogRuleProductProxy::modelClass());
     }
@@ -19,7 +20,7 @@ class CatalogRule extends BaseModel
     /**
      * Get the Catalog rule Product that owns the catalog rule.
      */
-    public function catalog_rule_product_prices()
+    public function catalog_rule_product_prices(): HasMany
     {
         return $this->hasMany(CatalogRuleProductPriceProxy::modelClass());
     }


### PR DESCRIPTION
Was getting this error after running composer command and it occurs because composer finds the below error as the models in GraphQL folder does not have HasMany relations declared while it is declared in the Models of Webkul package.

Please check below error generated during the installation of headless-ecommerce via composer
===============================================================
Generating optimized autoload files
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover --ansi

   Symfony\Component\ErrorHandler\Error\FatalError

  Declaration of Webkul\GraphQLAPI\Models\CatalogRule\CatalogRule::catalog_rule_products() must be compatible with Webkul\CatalogRule\Models\CatalogRule::catalog_rule_products(): Illuminate\Database\Eloquent\Relations\HasMany

  at vendor\bagisto\graphql-api\src\Models\CatalogRule\CatalogRule.php:14
     10▕ {
     11▕     /**
     12▕      * Get the Catalog rule Product that owns the catalog rule.
     13▕      */
  ➜  14▕     public function catalog_rule_products()
     15▕     {
     16▕         return $this->hasMany(CatalogRuleProductProxy::modelClass());
     17▕     }
     18▕


   Whoops\Exception\ErrorException

  Declaration of Webkul\GraphQLAPI\Models\CatalogRule\CatalogRule::catalog_rule_products() must be compatible with Webkul\CatalogRule\Models\CatalogRule::catalog_rule_products(): Illuminate\Database\Eloquent\Relations\HasMany

  at vendor\bagisto\graphql-api\src\Models\CatalogRule\CatalogRule.php:14
     10▕ {
     11▕     /**
     12▕      * Get the Catalog rule Product that owns the catalog rule.
     13▕      */
  ➜  14▕     public function catalog_rule_products()
     15▕     {
     16▕         return $this->hasMany(CatalogRuleProductProxy::modelClass());
     17▕     }
     18▕

  1   vendor\filp\whoops\src\Whoops\Run.php:514
      Whoops\Run::handleError("Declaration of Webkul\GraphQLAPI\Models\CatalogRule\CatalogRule::catalog_rule_products() must be compatible with Webkul\CatalogRule\Models\CatalogRule::catalog_rule_products(): Illuminate\Database\Eloquent\Relations\HasMany", "C:\laragon\www\bagisto\vendor\bagisto\graphql-api\src\Models\CatalogRule\CatalogRule.php")

  2   [internal]:0
      Whoops\Run::handleShutdown()

Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 255
==================================================================================

Just had to add HasMany Relation to the GraphQL API Models CatalogRule in vendor folder.