### PR TITLE
Add necessary types to enable the Booking Product extension on APIs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "require": {
         "php-open-source-saver/jwt-auth": "^2.1",
         "nuwave/lighthouse": "^6.23",
-        "mll-lab/laravel-graphiql": "^3.1"
+        "mll-lab/laravel-graphiql": "^3.1",
+        "mll-lab/graphql-php-scalars": "^6.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Models/Product/Product.php
+++ b/src/Models/Product/Product.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Webkul\GraphQLAPI\Models\Product;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Webkul\BookingProduct\Models\BookingProductProxy;
+use Webkul\Product\Models\Product as BaseProduct;
+
+class Product extends BaseProduct
+{
+    /**
+     * The bookings that belong to the product.
+     */
+    public function booking_product(): BelongsTo
+    {
+        return $this->belongsTo(BookingProductProxy::modelClass(), 'id', 'product_id');
+    }
+}

--- a/src/Providers/GraphQLAPIServiceProvider.php
+++ b/src/Providers/GraphQLAPIServiceProvider.php
@@ -60,10 +60,12 @@ class GraphQLAPIServiceProvider extends ServiceProvider
         );
 
         // Product Models
-        $this->app->concord->registerModel(
-            \Webkul\Product\Models\Product::class,
-            \Webkul\GraphQLAPI\Models\Product\Product::class
-        );
+        if (class_exists(\Webkul\BookingProduct\Models\BookingProductProxy::class)) {
+            $this->app->concord->registerModel(
+                \Webkul\Product\Models\Product::class,
+                \Webkul\GraphQLAPI\Models\Product\Product::class
+            );
+        }
     }
 
     /**

--- a/src/Providers/GraphQLAPIServiceProvider.php
+++ b/src/Providers/GraphQLAPIServiceProvider.php
@@ -58,6 +58,12 @@ class GraphQLAPIServiceProvider extends ServiceProvider
             \Webkul\CartRule\Contracts\CartRule::class,
             \Webkul\GraphQLAPI\Models\CartRule\CartRule::class
         );
+
+        // Product Models
+        $this->app->concord->registerModel(
+            \Webkul\Product\Models\Product::class,
+            \Webkul\GraphQLAPI\Models\Product\Product::class
+        );
     }
 
     /**

--- a/src/Queries/Admin/Catalog/Products/ProductContent.php
+++ b/src/Queries/Admin/Catalog/Products/ProductContent.php
@@ -343,4 +343,18 @@ class ProductContent extends BaseFilter
     {
         return route('shop.product_or_category.index', $product->url_key);
     }
+
+    /**
+     * Get product booking product.
+     *
+     * @return mixed
+     */
+    public function getBookingProduct($product): mixed
+    {
+        if (method_exists($product, 'booking_product')) {
+            return $product->booking_product;
+        }
+
+        return null;
+    }
 }

--- a/src/graphql/admin/catalog/products/product.graphql
+++ b/src/graphql/admin/catalog/products/product.graphql
@@ -190,51 +190,51 @@ type BookingProduct {
     type: String!
     qty: Int
     location: String
-    show_location: Boolean
-    available_every_week: Boolean
-    available_from: DateTime
-    available_to: DateTime
-    default_slot: BookingProductDefaultSlot @hasOne(relation: "default_slot")
-    appointment_slot: BookingProductAppointmentSlot @hasOne(relation: "appointment_slot")
-    rental_slot: BookingProductRentalSlot @hasOne(relation: "rental_slot")
-    table_slot: BookingProductTableSlot @hasOne(relation: "table_slot")
-    event_tickets: [BookingProductEventTicket] @hasMany(relation: "event_tickets")
+    showLocation: Boolean @rename(attribute: "show_location")
+    availableEveryWeek: Boolean @rename(attribute: "available_every_week")
+    availableFrom: DateTime @rename(attribute: "available_from")
+    availableTo: DateTime @rename(attribute: "available_to")
+    defaultSlot: BookingProductDefaultSlot @hasOne(relation: "default_slot")
+    appointmentSlot: BookingProductAppointmentSlot @hasOne(relation: "appointment_slot")
+    rentalSlot: BookingProductRentalSlot @hasOne(relation: "rental_slot")
+    tableSlot: BookingProductTableSlot @hasOne(relation: "table_slot")
+    eventTickets: [BookingProductEventTicket] @hasMany(relation: "event_tickets")
     product: Product! @belongsTo(relation: "product")
 }
 
 type BookingProductDefaultSlot {
     id: ID!
-    booking_type: String!
+    bookingType: String! @rename(attribute: "booking_type")
     duration: Int
-    break_time: Int
+    breakTime: Int @rename(attribute: "break_time")
     slots: JSON
 }
 
 type BookingProductAppointmentSlot {
     id: ID!
     duration: Int
-    break_time: Int
-    same_slot_all_days: Boolean
+    breakTime: Int @rename(attribute: "break_time")
+    sameSlotAllDays: Boolean @rename(attribute: "same_slot_all_days")
     slots: JSON
 }
 
 type BookingProductRentalSlot {
     id: ID!
-    renting_type: String!
-    daily_price: Float
-    hourly_price: Float
-    same_slot_all_days: Boolean
+    rentingType: String! @rename(attribute: "renting_type")
+    dailyPrice: Float @rename(attribute: "daily_price")
+    hourlyPrice: Float @rename(attribute: "hourly_price")
+    sameSlotAllDays: Boolean @rename(attribute: "same_slot_all_days")
     slots: JSON
 }
 
 type BookingProductTableSlot {
     id: ID!
-    price_type: String!
-    guest_limit: Int
+    priceType: String! @rename(attribute: "price_type")
+    guestLimit: Int @rename(attribute: "guest_limit")
     duration: Int!
-    break_time: Int!
-    prevent_scheduling_before: Int!
-    same_slot_all_days: Boolean
+    breakTime: Int! @rename(attribute: "break_time")
+    preventSchedulingBefore: Int! @rename(attribute: "prevent_scheduling_before")
+    sameSlotAllDays: Boolean @rename(attribute: "same_slot_all_days")
     slots: JSON
 }
 
@@ -242,9 +242,9 @@ type BookingProductEventTicket {
     id: ID!
     price: Float
     qty: Int
-    special_price: Float
-    special_price_from: DateTime
-    special_price_to: DateTime
+    specialPrice: Float @rename(attribute: "special_price")
+    specialPriceFrom: DateTime @rename(attribute: "special_price_from")
+    specialPriceTo: DateTime @rename(attribute: "special_price_to")
 }
 
 type ProductAttributeValue {

--- a/src/graphql/admin/catalog/products/product.graphql
+++ b/src/graphql/admin/catalog/products/product.graphql
@@ -182,6 +182,69 @@ type Product {
     relatedProducts: [Product!] @belongsToMany(relation: "related_products")
     upSells: [Product] @belongsToMany(relation: "up_sells")
     crossSells: [Product] @belongsToMany(relation: "cross_sells")
+    bookingProduct: BookingProduct @field(resolver: "Webkul\\GraphQLAPI\\Queries\\Admin\\Catalog\\Products\\ProductContent@getBookingProduct")
+}
+
+type BookingProduct {
+    id: ID!
+    type: String!
+    qty: Int
+    location: String
+    show_location: Boolean
+    available_every_week: Boolean
+    available_from: DateTime
+    available_to: DateTime
+    default_slot: BookingProductDefaultSlot @hasOne(relation: "default_slot")
+    appointment_slot: BookingProductAppointmentSlot @hasOne(relation: "appointment_slot")
+    rental_slot: BookingProductRentalSlot @hasOne(relation: "rental_slot")
+    table_slot: BookingProductTableSlot @hasOne(relation: "table_slot")
+    event_tickets: [BookingProductEventTicket] @hasMany(relation: "event_tickets")
+    product: Product! @belongsTo(relation: "product")
+}
+
+type BookingProductDefaultSlot {
+    id: ID!
+    booking_type: String!
+    duration: Int
+    break_time: Int
+    slots: JSON
+}
+
+type BookingProductAppointmentSlot {
+    id: ID!
+    duration: Int
+    break_time: Int
+    same_slot_all_days: Boolean
+    slots: JSON
+}
+
+type BookingProductRentalSlot {
+    id: ID!
+    renting_type: String!
+    daily_price: Float
+    hourly_price: Float
+    same_slot_all_days: Boolean
+    slots: JSON
+}
+
+type BookingProductTableSlot {
+    id: ID!
+    price_type: String!
+    guest_limit: Int
+    duration: Int!
+    break_time: Int!
+    prevent_scheduling_before: Int!
+    same_slot_all_days: Boolean
+    slots: JSON
+}
+
+type BookingProductEventTicket {
+    id: ID!
+    price: Float
+    qty: Int
+    special_price: Float
+    special_price_from: DateTime
+    special_price_to: DateTime
 }
 
 type ProductAttributeValue {

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -8,6 +8,9 @@ scalar DateTime @scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\Date
 scalar Upload
   @scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\Upload")
 
+scalar JSON
+  @scalar(class: "MLL\\GraphQLScalars\\JSON")
+
 #import /admin/sales/orders/*.graphql
 #import /admin/sales/invoices/*.graphql
 #import /admin/sales/shipments/*.graphql


### PR DESCRIPTION
This pull request adds the necessary types to support the Booking Product extension on the APIs. To make this fully functional, anyone who installs the Booking Product extension needs to add the following relation to the Webkul\Product model:

`public function booking_product(): BelongsTo
{
    return $this->belongsTo(BookingProductProxy::modelClass(), 'id', 'product_id');
}`

- If the relation is not added, the application will still run without errors.
- In such cases, the booking_product relation will return null when accessed via the GraphQL API.