### PR TITLE
Add FilterItem class and update GraphQL schemas for additional data retrieval

### DIFF
--- a/src/Queries/Shop/Common/FilterItem.php
+++ b/src/Queries/Shop/Common/FilterItem.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Webkul\GraphQLAPI\Queries\Shop\Common;
+
+use Webkul\GraphQLAPI\Queries\BaseFilter;
+
+class FilterItem extends BaseFilter
+{
+    /**
+     * Get the additional data for the cart item.
+     */
+    public function additional(object $model)
+    {
+        $additional = $model->additional;
+
+        $additional['attributes'] = collect($additional['attributes'] ?? [])
+            ->values()
+            ->all();
+
+        return $additional;
+    }
+}

--- a/src/Queries/Shop/Customer/WishlistQuery.php
+++ b/src/Queries/Shop/Customer/WishlistQuery.php
@@ -63,26 +63,4 @@ class WishlistQuery extends BaseFilter
             'customer_id' => auth()->user()->id,
         ]);
     }
-
-    /**
-     * This function retrieves additional data for each item in the wishlist.
-     *
-     * @param  object  $query
-     * @return \Illuminate\Support\Collection
-     */
-    public function getAdditionData($query)
-    {
-        // The get() method retrieves all records from the database.
-        // The map() method iterates through each item in the collection,
-        // allowing us to transform the item's value and key.
-        // The flatten() method is used to flatten a multi-dimensional collection into a single dimension.
-        return $query->get()->map(function ($wishlistItem) {
-            return collect($wishlistItem->additional)->transform(function ($additional, $key) {
-                return [
-                    'key'   => $key,
-                    'value' => $additional,
-                ];
-            })->all();
-        })->flatten(1);
-    }
 }

--- a/src/graphql/admin/sales/invoices/invoice.graphql
+++ b/src/graphql/admin/sales/invoices/invoice.graphql
@@ -130,7 +130,7 @@ type InvoiceItem {
     productType: String @rename(attribute: "product_type")
     orderItemId: ID! @rename(attribute: "order_item_id")
     invoiceId: ID! @rename(attribute: "invoice_id")
-    additional: JSON
+    additional: JSON @field(resolver: "Webkul\\GraphQLAPI\\Queries\\Shop\\Common\\FilterItem@additional")
     createdAt: DateTime @rename(attribute: "created_at")
     updatedAt:DateTime @rename(attribute: "updated_at")
     formattedPrice: FormattedPrice @field(resolver: "Webkul\\GraphQLAPI\\Queries\\Sales\\FormattedPrice@getInvoiceItemPriceData")

--- a/src/graphql/admin/sales/orders/order.graphql
+++ b/src/graphql/admin/sales/orders/order.graphql
@@ -191,14 +191,9 @@ type OrderPayment {
     orderId: ID @rename(attribute: "order_id")
     method: String!
     methodTitle: String @field(resolver: "Webkul\\GraphQLAPI\\Queries\\Shop\\Customer\\OrderQuery@getOrderPaymentTitle")
-    additional: OrderPaymentAdditional @field(resolver: "Webkul\\GraphQLAPI\\Queries\\Shop\\Customer\\OrderQuery@getOrderPaymentAdditional")
+    additional: JSON @field(resolver: "Webkul\\GraphQLAPI\\Queries\\Shop\\Customer\\OrderQuery@getOrderPaymentAdditional")
     createdAt: DateTime @rename(attribute: "created_at")
     updatedAt: DateTime @rename(attribute: "updated_at")
-}
-
-type OrderPaymentAdditional {
-    title: String
-    value: String
 }
 
 type CancelOrderResponse {

--- a/src/graphql/admin/sales/orders/order_item.graphql
+++ b/src/graphql/admin/sales/orders/order_item.graphql
@@ -77,7 +77,7 @@ type OrderItem {
     orderId: ID! @rename(attribute: "order_id")
     taxCategoryId: ID @rename(attribute: "tax_category_id")
     parentId: ID @rename(attribute: "parent_id")
-    additional: JSON
+    additional: JSON @field(resolver: "Webkul\\GraphQLAPI\\Queries\\Shop\\Common\\FilterItem@additional")
     createdAt: DateTime @rename(attribute: "created_at")
     updatedAt: DateTime @rename(attribute: "updated_at")
     order: Order! @belongsTo(relation: "order")

--- a/src/graphql/admin/sales/refunds/refund.graphql
+++ b/src/graphql/admin/sales/refunds/refund.graphql
@@ -136,7 +136,7 @@ type RefundItem {
     productType: String @rename(attribute: "product_type")
     orderItemId: Int @rename(attribute: "order_item_id")
     refundId: Int @rename(attribute: "refund_id")
-    additional: JSON
+    additional: JSON @field(resolver: "Webkul\\GraphQLAPI\\Queries\\Shop\\Common\\FilterItem@additional")
     createdAt: DateTime @rename(attribute: "created_at")
     updatedAt: DateTime @rename(attribute: "updated_at")
     formattedPrice: FormattedPrice @field(resolver: "Webkul\\GraphQLAPI\\Queries\\Sales\\FormattedPrice@getRefundItemPriceData")

--- a/src/graphql/admin/sales/shipments/shipment.graphql
+++ b/src/graphql/admin/sales/shipments/shipment.graphql
@@ -115,7 +115,7 @@ type ShipmentItem {
     productType: String @rename(attribute: "product_type")
     orderItemId: ID! @rename(attribute: "order_item_id")
     shipmentId: ID! @rename(attribute: "shipment_id")
-    additional: JSON
+    additional: JSON @field(resolver: "Webkul\\GraphQLAPI\\Queries\\Shop\\Common\\FilterItem@additional")
     createdAt: DateTime @rename(attribute: "created_at")
     updatedAt: DateTime @rename(attribute: "updated_at")
     shipment: Shipment! @belongsTo(relation: "shipment")

--- a/src/graphql/shop/cart/cart.graphql
+++ b/src/graphql/shop/cart/cart.graphql
@@ -155,7 +155,7 @@ type CartItem {
     cartId: ID! @rename(attribute: "cart_id")
     taxCategoryId: ID @rename(attribute: "tax_category_id")
     appliedCartRuleIds: String @rename(attribute: "applied_cart_rule_ids")
-    additional: JSON
+    additional: JSON @field(resolver: "Webkul\\GraphQLAPI\\Queries\\Shop\\Common\\FilterItem@additional")
     createdAt: DateTime @rename(attribute: "created_at")
     updatedAt: DateTime @rename(attribute: "updated_at")    
     formattedPrice: FormattedPrice @field(resolver: "Webkul\\GraphQLAPI\\Queries\\Shop\\Common\\FormattedPrice@getCartItemPriceData")

--- a/src/graphql/shop/customer/wishlist.graphql
+++ b/src/graphql/shop/customer/wishlist.graphql
@@ -50,7 +50,7 @@ type Wishlist {
     channelId: ID! @rename(attribute: "channel_id")
     productId: ID! @rename(attribute: "product_id")
     customerId: ID @rename(attribute: "customer_id")
-    additional: [FilterOption] @field(resolver: "Webkul\\GraphQLAPI\\Queries\\Shop\\Customer\\WishlistQuery@getAdditionData")
+    additional: JSON
     movedToCart: Boolean @rename(attribute: "moved_to_cart")
     shared: Boolean
     createdAt: DateTime @rename(attribute: "created_at")


### PR DESCRIPTION
### Add FilterItem class and update GraphQL schemas for additional data retrieval

- Introduced FilterItem class to handle additional data for cart items.
- Updated GraphQL schemas for InvoiceItem, OrderItem, RefundItem, ShipmentItem, CartItem, and Wishlist to use the new FilterItem resolver for additional data.
- Removed unused getAdditionData method from WishlistQuery.