### PR TITLE
Fix: Customer Address API allows multiple default addresses

### DIFF
--- a/src/Mutations/Shop/Customer/AddressesMutation.php
+++ b/src/Mutations/Shop/Customer/AddressesMutation.php
@@ -54,6 +54,13 @@ class AddressesMutation extends Controller
                 'address'     => implode(PHP_EOL, array_filter($args['address'])),
             ]);
 
+            if (! empty($args['default_address'])) {
+                $this->customerAddressRepository
+                    ->where('customer_id', $args['customer_id'])
+                    ->where('default_address', 1)
+                    ->update(['default_address' => 0]);
+            }
+
             $customerAddress = $this->customerAddressRepository->create($args);
 
             Event::dispatch('customer.addresses.create.after', $customerAddress);


### PR DESCRIPTION
When creating a customer address with default_address set, any existing default address for the customer is now unset to ensure only one default address exists at a time.